### PR TITLE
fix: avoid rate-limit by using authenticated github CLI to get latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,3 +21,26 @@ jobs:
           git config --global user.email "test@test.com"
           git config --global user.name "test"
           make test
+
+  action-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.head_ref }} # checkout the correct branch name
+          fetch-depth: 0 # fetch the whole repo history
+
+      - id: version
+        uses: ./
+        with:
+          skip-prerelease: true
+          major-identifier: "BREAKING CHANGE:"
+          minor-identifier: "feat:"
+          prefix: "v"
+
+      - name: New version
+        run: |
+          echo ${{ steps.version.outputs.version }}
+      - name: Previous version
+        run: |
+          echo ${{ steps.version.outputs.previous-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,27 @@ jobs:
           ref: ${{ github.head_ref }} # checkout the correct branch name
           fetch-depth: 0 # fetch the whole repo history
 
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+      - uses: ./
+
       - id: version
         uses: ./
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,27 +30,6 @@ jobs:
           ref: ${{ github.head_ref }} # checkout the correct branch name
           fetch-depth: 0 # fetch the whole repo history
 
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-      - uses: ./
-
       - id: version
         uses: ./
         with:

--- a/action.yml
+++ b/action.yml
@@ -52,13 +52,11 @@ runs:
     - shell: bash
       run: |
         set -eo pipefail
-        if [ "${{ inputs.tool-version }}" = "latest" ]; then
-          download_url="$(curl --retry 3 -L https://api.github.com/repos/linz/action-git-version/releases/latest | jq -r .assets[0].browser_download_url)"
-        else
-          download_url="https://github.com/linz/action-git-version/releases/download/${{ inputs.tool-version }}/git-version"
+        TAG_OPT=""
+        if [ "${{ inputs.tool-version }}" != "latest" ]; then
+          TAG_OPT="${{ inputs.tool-version }}"
         fi
-        echo "Downloading git-version from $download_url"
-        sudo curl --retry 3 -L "$download_url" -o /usr/local/bin/git-version
+        sudo gh release download $TAG_OPT --repo linz/action-git-version --pattern git-version --dir /usr/local/bin/ --clobber
         sudo chmod +x /usr/local/bin/git-version
     - id: previous-version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -53,12 +53,12 @@ runs:
       run: |
         set -eo pipefail
         if [ "${{ inputs.tool-version }}" = "latest" ]; then
-          download_url="$(curl -L https://api.github.com/repos/linz/action-git-version/releases/latest | jq -r .assets[0].browser_download_url)"
+          download_url="$(curl --retry 3 -L https://api.github.com/repos/linz/action-git-version/releases/latest | jq -r .assets[0].browser_download_url)"
         else
           download_url="https://github.com/linz/action-git-version/releases/download/${{ inputs.tool-version }}/git-version"
         fi
         echo "Downloading git-version from $download_url"
-        sudo curl -L "$download_url" -o /usr/local/bin/git-version
+        sudo curl --retry 3 -L "$download_url" -o /usr/local/bin/git-version
         sudo chmod +x /usr/local/bin/git-version
     - id: previous-version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -53,11 +53,12 @@ runs:
       run: |
         set -eo pipefail
         if [ "${{ inputs.tool-version }}" = "latest" ]; then
-          download_url="$(curl -Ls https://api.github.com/repos/linz/action-git-version/releases/latest | jq -r .assets[0].browser_download_url)"
+          download_url="$(curl -L https://api.github.com/repos/linz/action-git-version/releases/latest | jq -r .assets[0].browser_download_url)"
         else
           download_url="https://github.com/linz/action-git-version/releases/download/${{ inputs.tool-version }}/git-version"
         fi
-        sudo curl -Ls "$download_url" -o /usr/local/bin/git-version
+        echo "Downloading git-version from $download_url"
+        sudo curl -L "$download_url" -o /usr/local/bin/git-version
         sudo chmod +x /usr/local/bin/git-version
     - id: previous-version
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -50,6 +50,8 @@ runs:
   using: "composite"
   steps:
     - shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         set -eo pipefail
         TAG_OPT=""
@@ -58,6 +60,7 @@ runs:
         fi
         sudo gh release download $TAG_OPT --repo linz/action-git-version --pattern git-version --dir /usr/local/bin/ --clobber
         sudo chmod +x /usr/local/bin/git-version
+
     - id: previous-version
       shell: bash
       run: |

--- a/action.yml
+++ b/action.yml
@@ -52,13 +52,17 @@ runs:
     - shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        TOOL_VERSION: ${{ inputs.tool-version }}
       run: |
         set -eo pipefail
-        TAG_OPT=""
-        if [ "${{ inputs.tool-version }}" != "latest" ]; then
-          TAG_OPT="${{ inputs.tool-version }}"
+        if [ "$TOOL_VERSION" = "latest" ]; then
+          download_url="$(gh release view --repo linz/action-git-version --json assets | jq -r .assets[0].url)"
+        else
+          download_url="https://github.com/linz/action-git-version/releases/download/$TOOL_VERSION/git-version"
         fi
-        sudo gh release download $TAG_OPT --repo linz/action-git-version --pattern git-version --dir /usr/local/bin/ --clobber
+
+        echo "Downloading git-version from $download_url"
+        sudo curl --retry 3 -L "$download_url" -o /usr/local/bin/git-version
         sudo chmod +x /usr/local/bin/git-version
 
     - id: previous-version


### PR DESCRIPTION
https://linz.slack.com/archives/CMP0BQ2V7/p1750893775654279

tested from consumer repo too
https://github.com/linz/action-semantic-version/pull/17